### PR TITLE
deploy to documentation to webroot via CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bitbots_jenkins_library"]
+	path = bitbots_jenkins_library
+	url = git@github.com:bit-bots/bitbots_jenkins_library.git

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,11 +35,4 @@ pipeline {
             }
         }
     }
-
-    post {
-        cleanup {
-            sh 'docker container prune -f'
-            sh 'docker image prune -f'
-        }
-    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,8 @@ pipeline {
             agent { docker image: 'bitbots_builder', registryUrl: 'http://registry.bit-bots.de:5000'}
             steps {
                 linkCatkinWorkspace()
+                sh 'rosdep update'
+                sh 'rosdep install -iry --from-paths /catkin_ws/src'
                 catkinBuild()
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('bitbots_jenkins_library@implement_first_version')_
+@Library('bitbots_jenkins_library')_
 
 pipeline {
     agent any
@@ -39,6 +39,7 @@ pipeline {
 
         stage('Deploy') {
             agent { label 'webserver' }
+            when { branch 'master' }
             steps {
                 unstash 'docs_output'
                 deployDocs('bitbots_docs')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         }
 
         stage('Build packages') {
-            agent { docker image: 'bitbots_builder', registryUrl: 'http://registry.bit-bots.de:5000'}
+            agent { docker image: 'bitbots_builder', registryUrl: 'http://registry.bit-bots.de:5000', alwaysPull: true }
             steps {
                 linkCatkinWorkspace()
                 sh 'rosdep update'
@@ -27,7 +27,7 @@ pipeline {
         }
 
         stage('Document') {
-            agent { docker image: 'bitbots_builder', registryUrl: 'http://registry.bit-bots.de:5000' }
+            agent { docker image: 'bitbots_builder', registryUrl: 'http://registry.bit-bots.de:5000', alwaysPull: true }
             steps {
                 linkCatkinWorkspace()
                 catkinBuild("Documentation")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,17 @@ pipeline {
             steps {
                 linkCatkinWorkspace()
                 catkinBuild("Documentation")
+
+                stash includes: '**/docs/_out/**', name: 'docs_output'
                 archiveArtifacts artifacts: '**/docs/_out/**', onlyIfSuccessful: true
+            }
+        }
+
+        stage('Deploy') {
+            agent { label 'webserver' }
+            steps {
+                unstash 'docs_output'
+                deployDocs('bitbots_docs')
             }
         }
     }

--- a/bitbots_docs/package.xml
+++ b/bitbots_docs/package.xml
@@ -10,6 +10,8 @@
     <license>MIT</license>
 
     <buildtool_depend>catkin</buildtool_depend>
+    <build_depend>python3-sphinx-rtd-theme</build_depend>
+    <build_depend>python-breathe</build_depend>
 
     <export>
         <bitbots_documentation>

--- a/docker_builder/Dockerfile
+++ b/docker_builder/Dockerfile
@@ -22,7 +22,7 @@ RUN . /opt/ros/melodic/setup.sh && \
     chmod -R 740 /catkin_ws
 
 # Setup entrypoint
-USER $user:$group
+USER builder:builder
 COPY entrypoint.bash /entrypoint.bash
 ENTRYPOINT ["/entrypoint.bash"]
 CMD ["bash"]

--- a/docker_builder/Dockerfile
+++ b/docker_builder/Dockerfile
@@ -13,6 +13,9 @@ ADD sudoers /etc/sudoers
 # Add user
 RUN useradd -M -d /catkin_ws -s /bin/bash -u 1001 builder
 
+# Setup rosdep
+RUN rosdep update
+
 # Setup catkin workspace
 RUN . /opt/ros/melodic/setup.sh && \
     mkdir -p /catkin_ws/src; cd /catkin_ws && \

--- a/docker_builder/Dockerfile
+++ b/docker_builder/Dockerfile
@@ -3,9 +3,11 @@ FROM ros:melodic-ros-base-bionic AS bitbots-builder
 
 # Install system dependencies
 RUN apt-get update && \
+    apt-get remove -y ros-melodic-rosdoc-lite python-sphinx && \
     apt-get install -y sudo python3-pip python-pip python-coverage python-xmlrunner python-rospkg python-catkin-pkg \
-    python-catkin-lint python-rosdep ros-melodic-rosdoc-lite dia && \
-    python3 -m pip install rospkg catkin-pkg
+    python-catkin-lint python-rosdep dia \
+    python3-sphinx python3-sphinx-rtd-theme python3-breathe && \
+    python3 -m pip install rospkg catkin-pkg exhale
 
 # Install sudoers file
 ADD sudoers /etc/sudoers


### PR DESCRIPTION
This PR enables deployment of package bitbots_docs to documentation webroot via CI.
The Result can currently be seen in Jenkins and on [doku.bit-bots.de](http://doku.bit-bots.de/package/bitbots_docs/latest/index.html)

It does this in a way which I hope makes it easier to reproduce said behavior for other packages as well.