### PR TITLE
doc: fix filepaths

### DIFF
--- a/bitbots_docs/docs/manual/tutorials/pycharm-ros.rst
+++ b/bitbots_docs/docs/manual/tutorials/pycharm-ros.rst
@@ -11,8 +11,8 @@ Wenn `ROS Sourcen` angewendet wird, sollte dies nicht nötig sein.
 1. Settings --> Project:bitbots_meta --> Project Interpreter
 2. Zahnrad oben rechts neben dem Interpreter --> Show All
 3. Unterster Button auf der rechten Seite ("Show paths for the selected interpreter")
-4. Add --> `/opt/ros/melodic/lib/python3.7/site-packages`
-5. Add --> `<catkin_ws>/devel/lib/python3.7/site-packages`
+4. Add --> `/opt/ros/melodic/lib/python2.7/dist-packages`
+5. Add --> `<catkin_ws>/devel/lib/python2.7/dist-packages`
 
 ROS Sourcen
 ===========
@@ -25,7 +25,7 @@ PyCharm weiß somit genauso viel wie die Shell und kann theoretisch auch genauso
 
 2. ::
 
-    vim ~/local/share/applications/pycharm-with-ros.desktop
+    vim ~/.local/share/applications/pycharm-with-ros.desktop
 
 3. ::
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix filepaths
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
I changed the Pythonpaths for the ROS packages because in Ubuntu there exists no folder "/opt/ros/melodic/lib/python3.7/site-packages" or "<catkin_ws>/devel/lib/python3.7/site-packages".
Furthermore in the explanation of the ROS Sourcing there was a missing "." in the vim command.
## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
There is no related issue.
## Necessary checks
- [ ] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot

