### PR TITLE
ci: only install package when on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,7 @@ pipeline {
         }
 
         stage("Install package bitbots_docs") {
+            when { branch "master" }
             agent { 
                 docker {
                     image "registry.bit-bots.de:5000/bitbots_builder"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,8 @@ pipeline {
                     catkinBuild("bitbots_docs", "Documentation")
 
                     stash name: "bitbots_docs_docs", includes: "bitbots_docs/docs/_out/**"
+                    publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: false, reportDir: "bitbots_docs/docs/_out/",
+                            reportFiles: "index.html", reportName: "Built Documentation", reportTitles: ""])
                     cleanWs()
             }
         }
@@ -82,8 +84,6 @@ pipeline {
             steps {
                 unstash "bitbots_docs_docs"
                     deployDocs("bitbots_docs")
-                    publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: false, reportDir: "bitbots_docs/docs/_out/",
-                            reportFiles: "index.html", reportName: "Built Documentation", reportTitles: ""])
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,8 @@ pipeline {
         stage("Build docker container") {
             when { branch "master" }
             steps {
-                sh "docker build -t registry.bit-bots.de:5000/bitbots_builder --no-cache docker_builder"
-                    sh "docker push registry.bit-bots.de:5000/bitbots_builder"
+                sh "docker build -t registry.bit-bots.de/bitbots_builder --no-cache docker_builder"
+                    sh "docker push registry.bit-bots.de/bitbots_builder"
                     sh "docker image prune -f"
                     sh "docker container prune -f"
             }
@@ -21,8 +21,8 @@ pipeline {
         stage("Build package bitbots_docs") {
             agent { 
                 docker {
-                    image "registry.bit-bots.de:5000/bitbots_builder"
-                        registryUrl "http://registry.bit-bots.de:5000"
+                    image "registry.bit-bots.de/bitbots_builder"
+                        registryUrl "http://registry.bit-bots.de"
                         alwaysPull true
                         args "--volume /srv/shared_catkin_install_space:/srv/catkin_install"
                 }
@@ -38,8 +38,8 @@ pipeline {
         stage("Build main documentation") {
             agent { 
                 docker {
-                    image "registry.bit-bots.de:5000/bitbots_builder"
-                        registryUrl "http://registry.bit-bots.de:5000"
+                    image "registry.bit-bots.de/bitbots_builder"
+                        registryUrl "http://registry.bit-bots.de"
                         alwaysPull true
                         args "--volume /srv/shared_catkin_install_space:/srv/catkin_install:ro"
                 }
@@ -61,8 +61,8 @@ pipeline {
             when { branch "master" }
             agent { 
                 docker {
-                    image "registry.bit-bots.de:5000/bitbots_builder"
-                        registryUrl "http://registry.bit-bots.de:5000"
+                    image "registry.bit-bots.de/bitbots_builder"
+                        registryUrl "http://registry.bit-bots.de"
                         alwaysPull true
                         args "--volume /srv/shared_catkin_install_space:/srv/catkin_install"
                 }


### PR DESCRIPTION
this means that the install space which is shared between all pipelines
does not get polluted with unstable builds.

<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot

