### PR TITLE
bitbots_tools: Docs: Fix How to Doku

### DIFF
--- a/bitbots_docs/docs/manual/tutorials/Doku-How-To.rst
+++ b/bitbots_docs/docs/manual/tutorials/Doku-How-To.rst
@@ -18,7 +18,7 @@ Diese müssen entsprechend in den richtigen Versionen installiert werden.
 
         sudo apt remove python-sphinx
         sudo apt install python3-sphinx python3-sphinx-rtd_theme python3-breathe
-        pip3 install -u exhale
+        pip3 install exhale --user
 
 
 Existierende Doku bauen

--- a/bitbots_docs/docs/manual/tutorials/Doku-How-To.rst
+++ b/bitbots_docs/docs/manual/tutorials/Doku-How-To.rst
@@ -17,7 +17,7 @@ Diese müssen entsprechend in den richtigen Versionen installiert werden.
 .. code-block:: bash
 
         sudo apt remove python-sphinx
-        sudo apt install python3-sphinx python3-sphinx-rtd_theme python3-breathe
+        sudo apt install python3-sphinx python3-sphinx-rtd-theme python3-breathe
         pip3 install exhale --user
 
 

--- a/bitbots_docs/package.xml
+++ b/bitbots_docs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
     <name>bitbots_docs</name>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <description>Includes main Bit-Bots documentation and provides CMake helper functions to ease the creation of documentation</description>
 
     <maintainer email="7sell@finn-thorben.me">Finn-Thorben Sell</maintainer>


### PR DESCRIPTION
## Proposed changes
Fixes wrong command in `How to doku` tutorial by using `--user` instead of `-u`.

## Related issues
The option `-u` for `pip3 install` does not exist.

## Necessary checks
- [x] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
~- [ ] Test on the robot~

