### PR TITLE
coding style: add spaces around binary operators

### DIFF
--- a/bitbots_docs/docs/_static/bitbots_cpp_style.xml
+++ b/bitbots_docs/docs/_static/bitbots_cpp_style.xml
@@ -46,8 +46,6 @@
     <option name="BLANK_LINES_AROUND_METHOD" value="0" />
     <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
     <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false" />
-    <option name="SPACE_AROUND_EQUALITY_OPERATORS" value="false" />
-    <option name="SPACE_AROUND_MULTIPLICATIVE_OPERATORS" value="false" />
     <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
     <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
     <option name="FOR_STATEMENT_WRAP" value="1" />

--- a/bitbots_docs/package.xml
+++ b/bitbots_docs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
     <name>bitbots_docs</name>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <description>Includes main Bit-Bots documentation and provides CMake helper functions to ease the creation of documentation</description>
 
     <maintainer email="7sell@finn-thorben.me">Finn-Thorben Sell</maintainer>


### PR DESCRIPTION
## Proposed changes
Add spaces around binary operators as we already did, but for some reason this was wrong in the style file.

## Necessary checks
- [x] Update package version
~Run `catkin build`~
~Write documentation~
~Create issues for future work~
~Test on your machine~
~Test on the robot~
- [x] Put the PR on our Project board