### PR TITLE
IMU docs: Fix typos

### DIFF
--- a/bitbots_docs/docs/manual/hardware/imu_dxl.rst
+++ b/bitbots_docs/docs/manual/hardware/imu_dxl.rst
@@ -5,7 +5,7 @@ Bitbots IMU DXL Module
 `Github repository <https://github.com/bit-bots/bitbots_imu_dxl>`_
 
 
-<picture>
+<TODO picture>
 
 
 Features
@@ -21,13 +21,15 @@ Features
 * WS2812b RGB LEDs
 * 3 Buttons
 
+
 Software
 ========
 
 The software consists of two parts. Firstly the firmware which is installed on the ESP32 and
-secondly (at least for us) the ros_control based diver to communicate with the board.
-You can communicate to the board using the standard Dynamixel protocol 2.0 (version 1 may work but we did not test it)
-if you wish to write your own harware interface for it.
+secondly (at least for us) the :ref:`ros_control<ROS Control>`  based diver to communicate with the board.
+You can communicate to the board using the standard Dynamixel protocol version 2.0, if you wish to write your own hardware interface for it.
+Version 1 may also work, but we did not test it.
+
 
 Firmware
 --------
@@ -45,6 +47,9 @@ For flashing a ESP32 Wroom (without development board) we recommend a `programmi
 
 If the board is already soldered, the programming header can be used. The square pin is pin 1 (+3V3).
 Please refer to the schematic for the pinout. There is a :ref:`known issue<Known Issues>` with this.
+
+
+.. _ROS Control:
 
 ROS Control
 -----------
@@ -67,8 +72,8 @@ We have used hot air and destroyed some modules with it.
 RS485/TTL selection
 ===================
 
-R1 and R2 should not be populated if RS485 is used to communicate with the board.
-They must be installed if TTL is used.
+R1 and R2 should not be populated, if RS485 is used to communicate with the board.
+They must be installed, if TTL is used.
 
 
 Register Table
@@ -154,7 +159,7 @@ Register Table
 DXL
 ---
 
-**id**: Can be a value between 1 and 252. it is used to talk to the device over the Dynamixel bus.
+**id**: Can be a value between 1 and 252. It is used to talk to the device over the Dynamixel bus.
 
 **baud**: Can be a value between 0 and 7
 
@@ -178,7 +183,7 @@ DXL
 | 7     | 4.5M    | no     |
 +-------+---------+--------+
 
-We are reasonably certain that the other baud rates work as well since the ESP32 supports them.
+We are reasonably certain that the other baud rates work as well, since the ESP32 supports them.
 
 
 .. _LEDs:
@@ -253,7 +258,7 @@ This procedure should be performed when the IMU is not moving.
 It should be done relatively frequently.
 The gyro calibration is not persistent.
 
-**reset_gyro_calibration**: Resets the gyro calibration. Useful if the gyro was accidentally calibrated while moving.
+**reset_gyro_calibration**: Resets the gyro calibration. Useful, if the gyro was accidentally calibrated while moving.
 
 **calibrate_accel**: Starts the :ref:`accelerometer calibration routine<Accelerometer Calibration>`.
 
@@ -287,8 +292,8 @@ Accelerometer Calibration
 =========================
 
 It is necessary to calibrate the accelerometer once before using it.
-For this the accelerometer must be placed with the x,y, and z-axis pointing downwards and upwards once.
-We have designed the 3D printed case for the board in such a way that this is relatively easy.
+For this, the accelerometer must be placed with the x,y, and z-axis pointing downwards and upwards once.
+We have designed the 3D printed case for the board in such a way, that this is relatively easy.
 
 Before starting the calibration, you should check the accelerometer measurements.
 For each of the axes pointing downwards or upwards the value should be at least 7.5 m/s^2.
@@ -297,9 +302,9 @@ If this is not the case, you need to lower the **accel_calibration_threshold**.
 To perform the calibration procedure follow this procedure:
 
 1. Place the IMU on one of the 6 sides
-2. Set a 1 to the **calibrate_accel** register (rosservice call /imu/calibrate_accel if you are using our software)
+2. Set a 1 to the **calibrate_accel** register (``rosservice call /imu/calibrate_accel``, if you are using our software)
 3. Wait until the IMU responds to reads again (or around 5 seconds)
-4. repeat for remaining 5 sides
+4. Repeat for remaining 5 sides
 
-After the procedure you should check the values in the **accel_scale** and **accel_bias** registers.
+After the procedure, you should check the values in the **accel_scale** and **accel_bias** registers.
 Scale should be really close to 1 and bias can, in our experience, deviate by 1-2 m/s^2.


### PR DESCRIPTION
## Proposed changes
Fixes typos in IMU docs

## Related issues
Resolves issues in #75.

## Necessary checks
~- [ ] Run `catkin build`~
- [x] Write documentation
~- [ ] Create issues for future work~
- [x] Test on your machine
~- [ ] Test on the robot~
- [x] Put the PR on our Project board

