### PR TITLE
fix toctree captions

### DIFF
--- a/bitbots_docs/docs/index.rst
+++ b/bitbots_docs/docs/index.rst
@@ -31,10 +31,6 @@ The main repository is `bitbots_meta <https://github.com/bit-bots/bitbots_meta>`
     manual/software/*
 
 
-Hardware
-========
-
-
 .. toctree::
     :maxdepth: 1
     :glob:

--- a/bitbots_docs/docs/index.rst
+++ b/bitbots_docs/docs/index.rst
@@ -32,25 +32,21 @@ The main repository is `bitbots_meta <https://github.com/bit-bots/bitbots_meta>`
 
 
 Hardware
---------
+========
 
-
-Electronics
-^^^^^^^^^^^
 
 .. toctree::
     :maxdepth: 1
     :glob:
+    :caption: Electronics
 
     manual/hardware/electronics/*
 
 
-Mechanics
-^^^^^^^^^
-
 .. toctree::
     :maxdepth: 1
     :glob:
+    :caption: Mechanics
 
     manual/hardware/mechanics/*
 


### PR DESCRIPTION
## Proposed changes
Currently the toctree in the sidebar is a bit broken because it used normal captions and not toctree captions. This PR fixes it.


## Necessary checks
- [x] Run `catkin build`
- [x] Write documentation
- ~[ ] Create issues for future work~
- [x] Test on your machine
- [x] Put the PR on our Project board

