### PR TITLE
configure source installation for ci

### DIFF
--- a/bitbots_docs/.rdmanifest
+++ b/bitbots_docs/.rdmanifest
@@ -1,0 +1,14 @@
+---
+uri: 'https://github.com/bit-bots/bitbots_tools/archive/refs/heads/master.tar.gz'
+depends: []
+exec-path: 'bitbots_tools-master/bitbots_docs'
+check-presence-script: |
+  #!/bin/bash
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/bitbots_docs
+install-script: |
+  #!/bin/bash
+  if [[ ! -d $BITBOTS_CATKIN_WORKSPACE/src ]]; then
+    echo '$BITBOTS_CATKIN_WORKSPACE/src does not exist' > /dev/stderr
+  fi
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/bitbots_docs

--- a/rosdep_source.yml
+++ b/rosdep_source.yml
@@ -1,0 +1,7 @@
+---
+bitbots_docs:
+  ubuntu: &bitbots_docs
+    source:
+      uri: 'https://raw.githubusercontent.com/bit-bots/bitbots_tools/feature/rosdep_src_install/bitbots_docs/.rdmanifest'
+  debian: *bitbots_docs
+  fedora: *bitbots_docs


### PR DESCRIPTION
## Proposed changes
In CI we need to be able to install packages as dependencies. This PR configures rosdep in CI to know how our packages are found and also creates the relevant definitions for the packages of this repo.

https://github.com/bit-bots/bitbots_msgs/pull/19 shows this PR in action since the container that builds that PR is currently configured to use the changes from this PR.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

