### PR TITLE
Update documentation about ci and how-to-doku

### DIFF
--- a/bitbots_docs/docs/manual/software/ci.rst
+++ b/bitbots_docs/docs/manual/software/ci.rst
@@ -1,14 +1,104 @@
 ======================
 Continuous Integration
 ======================
-We have a Jenkins instance running at `ci.bit-bots.de <http://ci.bit-bots.de>`_ which automatically builds the current
-documentation located at `doku.bit-bots.de <http://doku.bit-bots.de>`_.
+We have a Jenkins instance running at `ci.bit-bots.de <http://ci.bit-bots.de>`_ which automatically builds
+the current documentation located at `doku.bit-bots.de <http://doku.bit-bots.de>`_.
+
+.. note:: If you only want to know what to do with your package and don't care about Jenkins internals you
+    only need :ref:`enable_ci_for_repo` and :ref:`make_package_resolvable_in_ci`.
+
+
+.. _enable_ci_for_repo:
+
+Enable CI for a Repository
+==========================
+CI is enabled on a per-repository basis and not per-package.
+Each repository which uses CI contains a configuration-as-code file called ``Jenkinsfile``.
+This file is located at the repository root and is written in Jenkins-DSL (domain specific language) which
+is based on Groovy which is based on Java.
+All our `Jenkinsfiles` mostly look the same and utilizes common logic defined in our
+`Pipeline Library <https://github.com/bit-bots/bitbots_jenkins_library>`_:
+
+.. code-block:: groovy
+    :linenos:
+
+    @Library('bitbots_jenkins_library') import de.bitbots.jenkins.*;
+
+    defineProperties()
+
+    def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
+    pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("bitbots_docs"), true, true, !isChangeRequest()))
+    pipeline.execute()
+
+
+Explained line by line:
+
+1. First we use the Jenkins Library `bitbots_jenkins_library` and import everything from it.
+
+3. We call `defineProperties() <https://github.com/bit-bots/bitbots_jenkins_library/blob/master/vars/defineProperties.groovy>`_
+   to set properties of this pipeline like when it is triggered and whether it may run concurrently.
+
+5. We create a `pipeline` variable of type `BitbotsPipeline <https://github.com/bit-bots/bitbots_jenkins_library/blob/master/src/de/bitbots/jenkins/BitbotsPipeline.groovy>`_.
+   This class contains most of the pipeline logic and is the main content of this library.
+
+6. We configure the pipeline to run for the package named *bitbots_docs*.
+   See `PackagePipelineSettings <https://github.com/bit-bots/bitbots_jenkins_library/blob/master/src/de/bitbots/jenkins/PackagePipelineSettings.groovy>`_
+   which configures what the pipeline should do and `PackageDefinition <https://github.com/bit-bots/bitbots_jenkins_library/blob/master/src/de/bitbots/jenkins/PackageDefinition.groovy>`_
+   which defines a packages name and where it is defined in the repo.
+
+   In this case, the pipeline should run for the package *bitbots_docs* which is located in a folder with the same name.
+   The pipeline should *build the package*, *document the package* and *publish the package* if
+   the current run is not a change request (meaning not a pull request).
+
+
+.. _make_package_resolvable_in_ci:
+
+Make Package resolvable in CI
+=============================
+When package a is used as a dependency by package b and package b is supposed to have CI enabled, a needs
+to be resolvable via rosdep.
+This section assumes you are the maintainer of package a and want to make your package resolvable.
+
+1. Create ``.rdmanifest`` file in your package (not repository) root with content like
+   the following:
+
+   .. code-block:: yaml
+
+        ---
+        # url where the packages repo can be downloaded as .tar.gz file
+        uri: 'https://github.com/bit-bots/<repo>/archive/refs/heads/master.tar.gz'
+        # other rosdep keys which this package depends on
+        depends: []
+        # directory to change to when installing the package <unpacked-tar-dir>/<package-dir>
+        exec-path: 'bitbots_tools-master/bitbots_docs'
+        # $BITBOTS_CATKIN_WORKSPACE is defined in CI and points to the current catkin workspace
+        check-presence-script: |
+          #!/bin/bash
+          test -d $BITBOTS_CATKIN_WORKSPACE/src/<package-name>
+        install-script: |
+          #!/bin/bash
+          cp -r . $BITBOTS_CATKIN_WORKSPACE/src/<package-name>
+
+   `.rdmanifest syntax reference <https://ros.org/reps/rep-0112.html#rdmanifest-syntax>`_
+
+2. Define the package in our own `rosdep definition`_ by creating an entry like the following:
+
+   .. code-block:: yaml
+
+        bitbots_docs:
+          ubuntu: &bitbots_docs
+            source:
+              uri: 'https://raw.githubusercontent.com/bit-bots/bitbots_tools/master/bitbots_docs/.rdmanifest'
+          debian: *bitbots_docs
+          fedora: *bitbots_docs
+
+
 
 
 Jenkins System Configuration
 ============================
-Jenkins is configured in two levels.
-One is the System-Configuration which is done via the Web-UI but contains only the bare minimum.
+The System-Configuration is done via the Web-UI or via configuration-as-code from
+`ansible <https://git.mafiasi.de/Bit-Bots/ansible/src/branch/master/host_vars/server/jenkins.yml>`_.
 In short it contains:
 
 :System Configuration: Only contains Security-Settings, which Github server to use, Jenkins base-url and
@@ -16,50 +106,47 @@ In short it contains:
 :Credentials: Passwords, SSH-Keys and Api-Tokens to access source control
 :bitbots_jenkins_library: This is a Jenkins Library (a collection of Groovy files) which can be loaded into
     a pipeline definition to provide common tasks.
-    Its code is contained in `bit-bots/bitbots_jenkins_library <https://github.com/bit-bots/bitbots_jenkins_library>`_.
-:Organisation Pipeline: This is the main Pipeline which builds most of our packages by indexing the Github Organisation.
-    The pipeline type is actually GitHub Organisation as well.
-    It is configured to search for repositories which contain a `Jenkinsfile` in its root folder and execute that
-    Jenkinsfile.
-:Non-Org Repo: Repositories which are not part of our Github Organisation and which are therefore not included in the
-    above pipeline are configured separately. They are of the pipeline type `Multibranch Pipeline` because we
-    might want to verify things before merging them into the master branch.
+    Its code is contained in `bit-bots/bitbots_jenkins_library <https://github.com/bit-bots/bitbots_jenkins_library>`_
+    and it must be registered in the Jenkins configuration so that it is loadable in pipelines.
 
-Jenkins is composed of a very small core and a metric ass-ton of plugins.
+Jenkins is composed of a very small core and a ton of plugins.
 One of these plugins is the Github Plugin which lets Jenkins scan our `Organisation <https://github.com/bit-bots/>`_
-for repositories with a valid configuration.
-
-
-Repository configuration
-========================
-Each repository which uses CI contains a configuration-as-code file called ``Jenkinsfile``.
-This file is located at the repository root and is written in Jenkins-DSL (domain specific language) a.k.a. Groovy.
-All our `Jenkinsfiles` mostly look the same:
-
-.. code-block:: groovy
-    :linenos:
-
-    @Library('bitbots_jenkins_library') import de.bitbots.jenkins.PackageDefinition
-
-    bitbotsPipeline([
-        new PackageDefinition("<package-name>", true),
-        new PackageDefinition("<package-name2>", true)
-    ] as PackageDefinition[])
-
-Explained line by line:
-
-1. First we use the Jenkins Library `bitbots_jenkins_library` and import the class `PackageDefinition` from it.
-We will need both later.
-
-3. We call `bitbotsPipeline` which is a function defined by the previously included Library.
-It is the main Entrypoint of each of our CI Pipelines.
-The function expects an array of `PackageDefinitions` for each of which it will execute a series of steps in
-parallel.
-
-4. Construction of a new PackageDefinition. This is a fairly staright-forward constructor call.
+for repositories with a valid configuration and automatically registers it in Jenkins.
 
 
 Build triggers
 ==============
 
-Some builds are run periodically while most GitHub builds are triggered via Webhooks as well.
+Some builds are run periodically while most GitHub builds are triggered via webhooks as well.
+
+These webhooks should be managed by the Github Plugin but in case that fails, Github must be configured
+as follows:
+
+:Payload URL: ``http://ci.bit-bots.de/github-webhook/``
+:Content Type: ``application/json``
+:Secret: Ask Finn or someone else who can see the current settings in Github.
+
+    If that is not possible update the credential ``github-webhook-secret`` in Jenkins to a new value and set
+    that in the webhook as well.
+:Which events?: Send everything
+
+
+Dependency Resolution Explained
+===============================
+
+Most of our packages have dependencies which are not normally resolvable via rosdep because they are our own
+packages. For example, `bitbots_msgs` depends on `bitbots_docs` in order to build documentation.
+To be able to resolve these dependencies while staying recent in their versions, a
+`rosdep definition`_ has been
+created which defines our packages as being installable via the `source` package manager.
+Each package also has a ``.rdmanifest`` file in its package directory which then teaches rosdep how exactly
+that package can be installed.
+The `bitbots_builder <https://github.com/bit-bots/containers/tree/main/bitbots_builder>`_ docker image
+(used by our CI) has this rosdep definition configured and is thus able to resolve our packages as
+dependencies.
+
+See `REP 111 <https://ros.org/reps/rep-0111.html>`_ and `REP 112 <https://ros.org/reps/rep-0112.html>`_
+for more documentation about rosdep.
+
+
+.. _rosdep definition: https://github.com/bit-bots/bitbots_tools/blob/master/rosdep_source.yml

--- a/bitbots_docs/docs/manual/tutorials/Docs-How-To.rst
+++ b/bitbots_docs/docs/manual/tutorials/Docs-How-To.rst
@@ -17,6 +17,8 @@ The correct version of the extentions must be installed.
         pip3 install exhale --user
 
 
+.. _build_documentation:
+
 How to build the documentation
 ==============================
 
@@ -31,6 +33,15 @@ How to build the documentation
   .. code-block:: bash
 
           catkin build <package> --no-deps --make-args Documentation
+
+* If you happen to build documentation a lot and don't want to always type the whole command, you can `define a catkin alias <https://catkin-tools.readthedocs.io/en/latest/advanced/verb_customization.html>`_
+  by creating the following file:
+
+  .. code-block:: yaml
+
+          # ~/.config/catkin/verb_aliases/01-doc.yaml
+          ---
+          doc: build --make-args Documentation --
 
 
 How to write documentation for a package
@@ -47,23 +58,20 @@ Preferably create your ``.rst`` documents in the directory ``docs/manual``, then
 
         manual/*
 
+
 .. _activate_docs_for_package:
 
 Activate documentation for a package
 ====================================
 
-
-
-
-Um Dokumentation für ein Paket wie oben beschrieben, schreiben zu können, muss das bauen der Doku für das
-entsprechende Paket aktiviert sein.
-
-Dadurch wird auch automatisch der Ordner ``docs/`` angelegt und eine initiale ``docs/conf.py`` und ``docs/index.rst``
-Datei angelegt.
+To be able to actually succeed in building documentation for a package as
+:ref:`described above <build_documentation>` that package must have documentation enabled.
+This can be done with the following steps and automatically creates the files ``docs/conf.py`` and
+``docs/index.rst``
 
 #) ``package.xml``:
-    Die ``package.xml`` beschreibt das Paket.
-    Wir fügen ihr nun eine Abhängigkeit auf das Paket `bitbtos_docs` hinzu.
+    The ``package.xml`` describes the package to the build system.
+    You need to add a dependency to ``bitbots_docs``.
 
     .. code-block:: xml
 
@@ -72,23 +80,24 @@ Datei angelegt.
         </package>
 
 #) ``CMakeLists.txt``:
-    In der ``CMakeLists.txt`` wird definiert, wie ein Paket gebaut wird.
-
-    Zuerst nutzen wir die Abhängigkeit auf `bitbots_docs`, um zusätzliche CMake Kommandos verfügbar zu machen:
+    This file describes how exactly a package is built.
+    First we need to add the ``bitbots_docs`` dependency here as well in order to make additional cmake
+    commands available.
 
     .. code-block:: cmake
 
         find_package(catkin COMPONENT bitbots_docs)
 
-    Dadurch wurde das Kommando `enable_bitbots_docs()` geladen, welches Dokumentation für dieses Paket aktiviert.
+    This registered the command ``enable_bitbots_docs()`` which is used to register the `Documentation`
+    target for this package and thus enables building documentation.
 
     .. code-block:: cmake
 
         enable_bitbots_docs()
 
 #) ``.gitignore``:
-    Diese Anpassungen sind nicht zwingend jedoch empfohlen, um das Git Repo nicht mit überflüssigen
-    Dateien vollzumüllen:
+    These additions are not strictly necessary but since we use git for all our packages you should do it
+    anyways. It is only required once per repository and not per package.
 
     .. code-block:: text
 
@@ -98,39 +107,4 @@ Datei angelegt.
         **/docs/cppapi
         **/docs/pyapi
 
-#) ``Jenkinsfile``:
-    Die Jenkinsfile ist nicht für die Doku an sich notwendig jedoch steuert sie unsere CI und damit das automatische Bauen der Doku.
-    Die Jenkinsfile ist in groovy zu schreiben, was ähnlich wie Java ist.
-
-    .. seealso:: :doc:`../software/ci` for a more detailed description of how our CI works.
-
-    .. note:: Nur `<package-name>` muss geändert werden:
-
-    .. code-block:: groovy
-
-CI für ein Repository aktivieren
-================================
-
-Damit die Dokumentation von Paketen auch automatisch gebaut wird, muss unserem CI-System (Jenkins) auch beschrieben
-werden, wie dies geht.
-
-.. todo:: Jenkins Dokument referenzieren
-
-Dafür muss die Datei ``Jenkinsfile`` im Hauptordner des Git Repositories angelegt werden.
-Die Jenkinsfile ist in groovy zu schreiben, was ähnlich wie Java ist.
-
-.. note:: Nur `<package-name>` muss geändert werden:
-
-.. code-block:: groovy
-
-    @Library('bitbots_jenkins_library') import de.bitbots.jenkins.PackageDefinition
-
-    bitbotsPipeline([
-        new PackageDefinition("<package-name>", true)
-    ] as PackageDefinition[])
-
-
-Damit wird unsere Jenkins Bibliothek eingebunden und danach die ``bitbotsPipeline`` gestartet.
-Diese braucht ein Array an Paketdefinitionen.
-Der Konstruktor akzeptiert den Paketnamen und dann, ob Doku gebaut werden soll.
-Da wir Doku bauen wollen, muss das 2. Argument auf true gesetzt werden.
+.. note:: See :doc:`../software/ci` for information about building the documentation automatically via Jenkins


### PR DESCRIPTION
## Proposed changes
I have updated the documentation around how-to-document and our CI.
Please let me know if it is understandable, especially if it is clear what someone needs to do when they want their package to be used in CI.

## Necessary checks
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [x] Put the PR on our Project board

