### PR TITLE
reference gen_rdmanifest script in docs

### DIFF
--- a/bitbots_docs/docs/manual/software/ci.rst
+++ b/bitbots_docs/docs/manual/software/ci.rst
@@ -59,25 +59,9 @@ When package a is used as a dependency by package b and package b is supposed to
 to be resolvable via rosdep.
 This section assumes you are the maintainer of package a and want to make your package resolvable.
 
-1. Create ``.rdmanifest`` file in your package (not repository) root with content like
-   the following:
-
-   .. code-block:: yaml
-
-        ---
-        # url where the packages repo can be downloaded as .tar.gz file
-        uri: 'https://github.com/bit-bots/<repo>/archive/refs/heads/master.tar.gz'
-        # other rosdep keys which this package depends on
-        depends: []
-        # directory to change to when installing the package <unpacked-tar-dir>/<package-dir>
-        exec-path: 'bitbots_tools-master/bitbots_docs'
-        # $BITBOTS_CATKIN_WORKSPACE is defined in CI and points to the current catkin workspace
-        check-presence-script: |
-          #!/bin/bash
-          test -d $BITBOTS_CATKIN_WORKSPACE/src/<package-name>
-        install-script: |
-          #!/bin/bash
-          cp -r . $BITBOTS_CATKIN_WORKSPACE/src/<package-name>
+1. Create ``.rdmanifest`` file in your package (not repository) root by calling the script
+   ``gen_rdmanifest.py`` in *bitbots_meta*. It's options should be self-explanatory when calling with
+   `--help`.
 
    `.rdmanifest syntax reference <https://ros.org/reps/rep-0112.html#rdmanifest-syntax>`_
 


### PR DESCRIPTION
## Proposed changes
https://github.com/bit-bots/bitbots_meta/pull/90 introduces the `gen_rdmanifest.py` script to easily generate .rdmanifest files. This PR updates the documentation to reference that script.

## Related issues
https://github.com/bit-bots/bitbots_meta/pull/90

## Necessary checks
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [x] Put the PR on our Project board

