### PR TITLE
fix rosdep source syntax error

### DIFF
--- a/rosdep_source.yml
+++ b/rosdep_source.yml
@@ -21,7 +21,7 @@ bitbots_ceiling_cam:
   fedora: *bitbots_ceiling_cam
 
 bitbots_live_tool_rqt:
-  ubuntu: &bitbots_live_tool_rqt:
+  ubuntu: &bitbots_live_tool_rqt
     source: https://raw.githubusercontent.com/bit-bots/bitbots_misc/master/bitbots_live_tool_rqt/.rdmanifest
       uri:
   debian: *bitbots_live_tool_rqt


### PR DESCRIPTION
## Proposed changes
There was a yaml syntax error in our rosdep sources specification. This PR fixes that error

## Related issues
https://github.com/bit-bots/bitbots_motion/pull/236

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

