### PR TITLE
remove libcv-bridge-dev key from rosdep definition

### DIFF
--- a/rosdep_misc.yml
+++ b/rosdep_misc.yml
@@ -5,6 +5,3 @@
 beignet-dev:
   ubuntu: beignet-dev
   debian: beignet-dev
-libcv-bridge-dev:
-  ubuntu: libcv-bridge-dev
-  debian: libcv-bridge-dev


### PR DESCRIPTION
## Proposed changes
Having this key was an error on my part since I misinterpreted the
distribution.yaml file and now know that in fact a `cv_bridge` rosdep key
already exists

## Related issues
was discussed in #104 

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

