### PR TITLE
add bitbots_test rosdep definition

### DIFF
--- a/rosdep_source.yml
+++ b/rosdep_source.yml
@@ -28,6 +28,13 @@ bitbots_live_tool_rqt:
   debian: *bitbots_live_tool_rqt
   fedora: *bitbots_live_tool_rqt
 
+bitbots_test:
+  ubuntu: &bitbots_test
+    source:
+      uri: https://raw.githubusercontent.com/bit-bots/bitbots_tools/master/bitbots_test/.rdmanifest
+  debian: *bitbots_test
+  fedora: *bitbots_test
+
 bitbots_time_constraint:
   ubuntu: &bitbots_time_constraint
     source:


### PR DESCRIPTION
In #108 we added the `bitbots_test` package. Unfortunately we forgot to add a rosdep definition for it. This PR **does** add a rosdep definition