### PR TITLE
Add additional rosdep definitions

### DIFF
--- a/rosdep_source.yml
+++ b/rosdep_source.yml
@@ -168,6 +168,20 @@ bitbots_splines:
   debian: *bitbots_splines
   fedora: *bitbots_splines
 
+bitbots_localization:
+  ubuntu: &bitbots_localization
+    source:
+      uri: https://raw.githubusercontent.com/bit-bots/bitbots_navigation/master/bitbots_localization/.rdmanifest
+  debian: *bitbots_localization
+  fedora: *bitbots_localization
+
+bitbots_move_base:
+  ubuntu: &bitbots_move_base
+    source:
+      uri: https://raw.githubusercontent.com/bit-bots/bitbots_navigation/master/bitbots_move_base/.rdmanifest
+  debian: *bitbots_move_base
+  fedora: *bitbots_move_base
+
 white_balancer:
   ubuntu: &white_balancer
     source:


### PR DESCRIPTION
## Proposed changes
Adds the packages `bitbots_localization` and `bitbots_move_base` to our rosdep definitions.

## Related issues
Requires https://github.com/bit-bots/bitbots_navigation/pull/109 to be merged first

