### PR TITLE
Add a tag that is always added to webots tests

### DIFF
--- a/bitbots_test/src/bitbots_test/decorators.py
+++ b/bitbots_test/src/bitbots_test/decorators.py
@@ -4,7 +4,6 @@ import os
 import abc
 from functools import wraps
 from unittest import skip, SkipTest
-from bitbots_test.test_case import TestCase
 
 
 def tag(*tags: str) -> Callable:
@@ -96,6 +95,7 @@ def tag(*tags: str) -> Callable:
         if type(cls) != type:
             raise TypeError(f"@tag decorator can only be used on classes and not {type(cls)}")
 
+        from bitbots_test.test_case import TestCase
         if not issubclass(cls, TestCase):
             raise ValueError(f"@tag decorator can only be used on TestCase subclasses and not {cls.__name__}")
 

--- a/bitbots_test/src/bitbots_test/known_tags.py
+++ b/bitbots_test/src/bitbots_test/known_tags.py
@@ -2,3 +2,6 @@
 
 INTERACTIVE = "interactive"
 "Tests which require user interaction in order to be run"
+
+WEBOTS = "webots"
+"Tests which require webots"

--- a/bitbots_test/src/bitbots_test/test_case.py
+++ b/bitbots_test/src/bitbots_test/test_case.py
@@ -9,6 +9,8 @@ import geometry_msgs.msg
 from rosgraph_msgs.msg import Log as LogMsg
 import std_srvs.srv
 import bitbots_msgs.srv
+from bitbots_test.decorators import tag
+from bitbots_test.known_tags import WEBOTS
 import gazebo_msgs.msg
 from datetime import datetime, timedelta
 from unittest.case import TestCase as BaseTestCase
@@ -211,6 +213,7 @@ class RosNodeTestCase(RosLogAssertionMixins, RosNodeAssertionMixins, TestCase):
         return f"{type(self).__name__}"
 
 
+@tag(WEBOTS)
 class WebotsTestCase(RosNodeTestCase):
     """A specific TestCase class which offers utility methods when running in a webots simulator"""
     _SUPERVISOR_NODE_NAME = "/webots_ros_supervisor"


### PR DESCRIPTION
## Proposed changes
This PR adds a tag "webots" that is added to all webots tests so that they can easily be skipped with `export TEST_TAGS='!webots'`.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

