### PR TITLE
fix build by replacing outdated ros test

### DIFF
--- a/bitbots_test/CMakeLists.txt
+++ b/bitbots_test/CMakeLists.txt
@@ -7,20 +7,20 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(rostest REQUIRED)
+find_package(ament_cmake_gtest REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(bitbots_docs REQUIRED)
 
-set(INCLUDE_DIRS include ${ament_cmake_INCLUDE_DIRS} ${rostest_INCLUDE_DIRS}
+set(INCLUDE_DIRS include ${ament_cmake_INCLUDE_DIRS} ${ament_cmake_gtest_INCLUDE_DIRS}
   ${rclcpp_INCLUDE_DIRS} ${bitbots_docs_INCLUDE_DIRS})
 include_directories(${INCLUDE_DIRS})
 
-set(LIBRARY_DIRS ${ament_cmake_LIBRARY_DIRS} ${rostest_LIBRARY_DIRS}
+set(LIBRARY_DIRS ${ament_cmake_LIBRARY_DIRS} ${ament_cmake_gtest_LIBRARY_DIRS}
   ${rclcpp_LIBRARY_DIRS} ${bitbots_docs_LIBRARY_DIRS})
 
 link_directories(${LIBRARY_DIRS})
 
-set(LIBS ${ament_cmake_LIBRARIES} ${rostest_LIBRARIES} ${rclcpp_LIBRARIES}
+set(LIBS ${ament_cmake_LIBRARIES} ${ament_cmake_gtest_LIBRARIES} ${rclcpp_LIBRARIES}
   ${bitbots_docs_LIBRARIES})
 
 set(CMAKE_CXX_STANDARD 17)
@@ -50,7 +50,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_dependencies(ament_cmake)
-ament_export_dependencies(rostest)
+ament_export_dependencies(ament_cmake_gtest)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(bitbots_docs)
 ament_export_include_directories(${INCLUDE_DIRS})

--- a/bitbots_test/package.xml
+++ b/bitbots_test/package.xml
@@ -17,7 +17,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>bitbots_docs</build_depend>
-  <depend>rostest</depend>
+  <depend>ament_cmake_gtest</depend>
   <depend>roscpp</depend>
   <depend>rosunit</depend>
   <depend>rosgraph_msgs</depend>


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
rostest is outdated and should be replaced, see: https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Migration-Guide.html?highlight=rostest
Now package builds at least

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

