### PR TITLE
Small fixes for installation guide

### DIFF
--- a/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
+++ b/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
@@ -13,7 +13,12 @@ If you are not already using Ubuntu 22.04, consider installing it on your system
 
 - Follow this guide and when it comes to the section **Install ROS 2 packages**, install the recommended `ros-rolling-desktop`: https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html
 - Follow the instructions (only the first two blocks) on https://packages.bit-bots.de/
-- Install additional dependencies: ``sudo apt install espeak ffmpeg libfmt-dev librange-v3-dev librostest-dev libtf-conversions-dev liburdfdom-dev libyaml-cpp-dev python3-colcon-common-extensions python3-pybind11 python3-rosdep ros-rolling-ament-cmake-nose ros-rolling-backward-ros ros-rolling-behaviortree-cpp-v3 ros-rolling-bondcpp ros-rolling-camera-info-manager ros-rolling-control-msgs ros-rolling-control-toolbox ros-rolling-controller-interface ros-rolling-controller-manager ros-rolling-desktop ros-rolling-diagnostic-aggregator ros-rolling-diagnostic-updater ros-rolling-effort-controllers ros-rolling-gazebo-msgs ros-rolling-image-proc ros-rolling-joint-state-broadcaster ros-rolling-joint-state-publisher-gui ros-rolling-joint-trajectory-controller ros-rolling-joy ros-rolling-joy-linux ros-rolling-moveit-core ros-rolling-moveit-planners-ompl ros-rolling-moveit-ros ros-rolling-moveit-ros-move-group ros-rolling-moveit-ros-planning ros-rolling-moveit-ros-planning-interface ros-rolling-moveit-ros-robot-interaction ros-rolling-moveit-simple-controller-manager ros-rolling-nav2-bringup ros-rolling-plotjuggler-ros ros-rolling-position-controllers ros-rolling-robot-localization ros-rolling-rot-conv ros-rolling-soccer-vision-2d-msgs ros-rolling-soccer-vision-3d-msgs ros-rolling-test-msgs ros-rolling-tf-transformations ros-rolling-transmission-interface ros-rolling-velocity-controllers ros-rolling-vision-msgs ros-rolling-xacro``
+- Install additional dependencies: ``sudo apt install espeak ffmpeg libfmt-dev librange-v3-dev librostest-dev libtf-conversions-dev liburdfdom-dev libyaml-cpp-dev protobuf-compiler python3-colcon-common-extensions python3-pybind11 python3-rosdep ros-rolling-ament-cmake-nose ros-rolling-backward-ros ros-rolling-behaviortree-cpp-v3 ros-rolling-bondcpp ros-rolling-camera-info-manager ros-rolling-control-msgs ros-rolling-control-toolbox ros-rolling-controller-interface ros-rolling-controller-manager ros-rolling-desktop ros-rolling-diagnostic-aggregator ros-rolling-diagnostic-updater ros-rolling-effort-controllers ros-rolling-gazebo-msgs ros-rolling-image-proc ros-rolling-joint-state-broadcaster ros-rolling-joint-state-publisher-gui ros-rolling-joint-trajectory-controller ros-rolling-joy ros-rolling-joy-linux ros-rolling-moveit-core ros-rolling-moveit-planners-ompl ros-rolling-moveit-ros ros-rolling-moveit-ros-move-group ros-rolling-moveit-ros-occupancy-map-monitor ros-rolling-moveit-ros-planning ros-rolling-moveit-ros-planning-interface ros-rolling-moveit-ros-robot-interaction ros-rolling-moveit-simple-controller-manager ros-rolling-nav2-bringup ros-rolling-plotjuggler-ros ros-rolling-position-controllers ros-rolling-robot-localization ros-rolling-rot-conv ros-rolling-soccer-vision-2d-msgs ros-rolling-soccer-vision-3d-msgs ros-rolling-test-msgs ros-rolling-tf-transformations ros-rolling-transmission-interface ros-rolling-velocity-controllers ros-rolling-vision-msgs ros-rolling-xacro``
+
+**2. Install webots**
+
+- Navigate to https://github.com/cyberbotics/webots/releases and download the ``.deb`` file of **Webots2022b**.
+- Install it using the command ``sudo apt install ~/Downloads/webots_2022b_amd64.deb`` or similar, depending on your system setup.
 
 **2. Download our software**
 
@@ -97,7 +102,3 @@ In case you are not using the bash shell, replace ``~/.bashrc`` and ``bash`` wit
   alias sc='source \$COLCON_WS/install/setup.bash'
   alias sa='sr && sc'
   EOF
-
-**TODOs**
-
-- Install Webots simulator


### PR DESCRIPTION
## Proposed changes
This PR contains two small fixes for our installation guides:
- two packages are added: `protobuf-compiler` and `ros-rolling-moveit-ros-occupancy-map-monitor`.
- Webots installation instructions are added