### PR TITLE
Fix: Conditional dependency on wolfgang_webots_sim

### DIFF
--- a/bitbots_test/package.xml
+++ b/bitbots_test/package.xml
@@ -27,7 +27,7 @@
 
   <test_depend>boost</test_depend>
   <test_depend>python3-hypothesis</test_depend>
-  <test_depend>wolfgang_webots_sim</test_depend>
+  <test_depend condition="$IS_ROBOT != True">wolfgang_webots_sim</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Proposed changes
- Make dependency on `wolfgang_webots_sim` conditional (if we are on a robot)

## Related issues
bitbots_meta/pull/187
bitbots_meta/pull/189
bit-bots/bitbots_misc/pull/218

## Necessary checks
- [X] Put the PR on our Project board